### PR TITLE
Copy SSH public key to work dir

### DIFF
--- a/notebook/start-notebook.d/30_ssh-key.sh
+++ b/notebook/start-notebook.d/30_ssh-key.sh
@@ -12,6 +12,7 @@ elif grep -q 'BEGIN OPENSSH PRIVATE KEY' "$key_file"; then
   # https://github.com/paramiko/paramiko/issues/602
   # This is a trick to "update" the key file by setting the
   # passphrase to the same value, but it exports as PEM.
+  cp -p "$key_file" "$key_file".bak
   ssh-keygen -p -N "" -m pem -f "$key_file"
 fi
 


### PR DESCRIPTION
The ssh-key hub setup script will now copy the public key to the working directory since it seems to be something that paramiko is expecting. This should fix the SSH issues some users were encountering in JupyterHub.

Fixes https://github.com/ChameleonCloud/python-chi/issues/13.
