### PR TITLE
Trovi 2.0: Adapt upload flow to upload to Trovi API instead of Swift

### DIFF
--- a/.env
+++ b/.env
@@ -25,9 +25,12 @@ ARTIFACT_SHARING_SWIFT_ACCOUNT=
 OS_AUTH_URL=https://dev.uc.chameleoncloud.org:5000/v3
 OS_REGION_NAME=CHI_DEV_UC
 KEYCLOAK_SERVER_URL=https://auth.dev.chameleoncloud.org
+TROVI_URL=https://trovi-dev.chameleoncloud.org
 
 # Production
 #ARTIFACT_SHARING_SWIFT_ACCOUNT=570aad8999f7499db99eae22fe9b29bb
 #OS_AUTH_URL=https://chi.uc.chameleoncloud.org:5000/v3
 #OS_REGION_NAME=CHI@UC
 #KEYCLOAK_SERVER_URL=https://auth.chameleoncloud.org
+#TROVI_URL=https://trovi.chameleoncloud.org
+


### PR DESCRIPTION
Adds a `TROVI_URL` env variable
